### PR TITLE
타임어택 제한시간 버그 수정

### DIFF
--- a/BlockKing/blockking.py
+++ b/BlockKing/blockking.py
@@ -779,7 +779,7 @@ def set_music_playing_speed(CHANNELS, swidth, Change_RATE):
     pygame.mixer.music.play(-1) #위 노래를 반복재생하기 위해 play(-1)로 설정
 
 def set_initial_values():
-    global combo_count, combo_count_2P, score, level, goal, score_2P, level_2P, goal_2P, bottom_count, bottom_count_2P, hard_drop, hard_drop_2P, attack_point, attack_point_2P, dx, dy, dx_2P, dy_2P, rotation, rotation_2P, mino, mino_2P, next_mino1, next_mino2, next_mino1_2P, hold, hold_2P, hold_mino, hold_mino_2P, framerate, framerate_2P, matrix, matrix_2P, Change_RATE, blink, start, pause, done, game_over, leader_board, setting, volume_setting, screen_setting, pvp, help, gravity_mode, debug, d, e, b, u, g, time_attack, start_ticks, textsize, CHANNELS, swidth, name_location, name, previous_time, current_time, previous_time_2P, current_time_2P,pause_time, lines, leaders, volume, game_status, framerate_blockmove, framerate_2P_blockmove, game_speed, game_speed_2P
+    global combo_count, combo_count_2P, score, level, goal, score_2P, level_2P, goal_2P, bottom_count, bottom_count_2P, hard_drop, hard_drop_2P, attack_point, attack_point_2P, dx, dy, dx_2P, dy_2P, rotation, rotation_2P, mino, mino_2P, next_mino1, next_mino2, next_mino1_2P, hold, hold_2P, hold_mino, hold_mino_2P, framerate, framerate_2P, matrix, matrix_2P, Change_RATE, blink, start, pause, done, game_over, leader_board, setting, volume_setting, screen_setting, pvp, help, gravity_mode, debug, d, e, b, u, g, time_attack, time_attack_time_setting, textsize, CHANNELS, swidth, name_location, name, previous_time, current_time, previous_time_2P, current_time_2P,pause_time, lines, leaders, volume, game_status, framerate_blockmove, framerate_2P_blockmove, game_speed, game_speed_2P
     framerate = 30 # Bigger -> Slower  기본 블록 하강 속도, 2도 할만 함, 0 또는 음수 이상이어야 함
     framerate_blockmove = framerate * 3 # 블록 이동 시 속도
     game_speed = framerate * 20 # 게임 기본 속도
@@ -807,7 +807,7 @@ def set_initial_values():
     u = False
     g = False
     time_attack = False
-    start_ticks = pygame.time.get_ticks()
+    time_attack_time_setting = False # 타임어택 모드를 시작하였을 때 타임 세팅을 시작하여 경과 시간을 계산하기 위해 추가한 변수
     textsize = False
 
     # 게임 음악 속도 조절 관련 변수
@@ -1475,6 +1475,10 @@ while not done:
             speed_plus_button.draw(screen, (0, 0, 0))
             speed_minus_button.draw(screen, (0, 0, 0))
         if time_attack:
+            if time_attack_time_setting == False: # 타임어택 모드일 때 타임 세팅이 안 되어 있으면
+                start_ticks = pygame.time.get_ticks() # 현재 시간을 타임어택 모드 시작 시간이라고 설정하고
+                time_attack_time_setting = True # 타임 세팅이 완료되었다고 바꾼다.
+
             elapsed_time = (pygame.time.get_ticks() - start_ticks) / 1000 # 경과 시간 계산
         for event in pygame.event.get():
             pos = pygame.mouse.get_pos()


### PR DESCRIPTION

1. 타임어택 제한시간 버그 수정 완료 Closes #22 
` time_attack_time_setting ` 변수를 추가하고, 현재 시간을 측정해 `start_ticks`에 넣는 위치를 변경하였습니다.

타임어택모드를 시작하면 제한시간 60초부터 시작하지 않았습니다.
 `start_ticks = pygame.time.get_ticks()` 이 부분이 `def set_initial_values():` 부분에 있었고, initial value 설정은 게임 main loop 들어가기전에 수행됩니다. 따라서 타임어택 모드 진입이 아닌, 게임 메인화면(게임 실행) 진입시부터 시간 측정이 시작해 생긴 문제였습니다.

그래서 `start_ticks`를 `def set_initial_values():`에서 지웠습니다.
그리고` time_attack_time_setting ` 변수를 타임어택 모드를 시작하였을 때 타임 세팅을 시작하여 경과 시간을 계산하기 위해 추가했습니다. 초기값은 `False`입니다.
그래서 main loop에 진입하고, 타임어택 모드일 경우,  `False`이면 시간 계산을 위해 `start_ticks`에 현재 시간을 체크하고, `True`로 변경합니다.


간단한데 되게 오래 헤맸네욤,,